### PR TITLE
[IIIF-898] Set up pytest and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - '3.8'
+  - '3.7'
+  - '3.6'
+  - '3.5'
+install:
+  - pip install .
+before_script:
+  - pip install pytest
+script:
+  - pytest
+branches:
+  only:
+  - main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Festerize
+# Festerize &nbsp;[![Build Status](https://travis-ci.com/UCLALibrary/festerize.svg?branch=main)](https://travis-ci.com/UCLALibrary/festerize)
 
 Uploads CSV files to the Fester IIIF manifest service for processing.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ Festerize creates a folder (by default called `./output`) for all output. CSVs r
 
 Festerize also creates a log file in the output folder, named the current date and time of the run, with an extension of `.log`. By default, the start and end time of the run are added as INFO rows to this log file, but this can be disabled by setting the `--loglevel` option to `--loglevel ERROR`.
 
+## Development
+
+It is recommended that developers create a virtual environment for local Python development. After cloning the repository, here's a quick way to get setup:
+
+    #!/bin/bash
+
+    python3 -m venv venv_festerize
+    . venv_festerize/bin/activate
+    pip install -e . pytest
+
+To run the tests:
+
+    pytest
+
 ## Releases
 
 To create a new release:

--- a/test_festerize.py
+++ b/test_festerize.py
@@ -1,0 +1,6 @@
+class TestFesterize:
+    '''Tests for Festerize.'''
+
+    def test_true(self):
+        '''Tests that pytest is setup properly.'''
+        assert True


### PR DESCRIPTION
`festerize.py` isn't unit-testable right now, so the test is a no-op.

Also, I should say that I chose the target Python versions roughly based on my past experience with them. It sounds like our three main users are on 3.7.