### PR TITLE
[IIIF-1029] Add flag to update only manifest metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Any rows with an `Object Type` of `Collection` (i.e., "collection row") found in
 
 Any rows with an `Object Type` of `Work` (i.e., "work row") are used to expand or revise a previously created IIIF collection (corresponding to the collection that the work is a part of), as well as create a IIIF manifest corresponding to the work. A "work" is conceived of as a discrete object (e.g., a book or a photograph) that one would access as an individual item.
 
-Any rows with an `Object Type` of `Page` (i.e., "page row") are likewise used to expand or revise a previously created IIIF manifest (corresponding to the work that the page is a part of).
+Any rows with an `Object Type` of `Page` (i.e., "page row") are likewise used to expand or revise a previously created IIIF manifest (corresponding to the work that the page is a part of), unless the `--metadata-update` flag is used (in which case, page rows are ignored).
 
 After Fester creates or updates any IIIF collections or manifests, it updates and returns the CSV files to the user.
 
@@ -117,7 +117,7 @@ It is recommended that developers create a virtual environment for local Python 
 
     python3 -m venv venv_festerize
     . venv_festerize/bin/activate
-    pip install -e . black pytest
+    pip install -e . "black>=19.*,<20.*" pytest
 
 To run the tests:
 

--- a/festerize.py
+++ b/festerize.py
@@ -47,7 +47,7 @@ import requests
     "--metadata-update",
     "-m",
     is_flag=True,
-    help="Only update manifest (work) metadata.",
+    help="Only update manifest (work) metadata; don't update canvases (pages).",
 )
 @click.option(
     "--loglevel",

--- a/festerize.py
+++ b/festerize.py
@@ -44,6 +44,12 @@ import requests
     "--iiifhost", default=None, help="IIIF image server URL (optional)",
 )
 @click.option(
+    "--metadata-update",
+    "-m",
+    is_flag=True,
+    help="Only update manifest (work) metadata.",
+)
+@click.option(
     "--loglevel",
     type=click.Choice(["INFO", "DEBUG", "ERROR"]),
     default="INFO",
@@ -52,7 +58,17 @@ import requests
 @click.option(
     "--version", "-V", is_flag=True, help="Print the version number and exit."
 )
-def cli(src, iiif_api_version, server, endpoint, out, iiifhost, loglevel, version):
+def cli(
+    src,
+    iiif_api_version,
+    server,
+    endpoint,
+    out,
+    iiifhost,
+    metadata_update,
+    loglevel,
+    version,
+):
     """Uploads CSV files to the Fester IIIF manifest service for processing.
 
     Uploads CSV files to the Fester IIIF manifest service for processing.
@@ -69,7 +85,8 @@ def cli(src, iiif_api_version, server, endpoint, out, iiifhost, loglevel, versio
 
     Any rows with an `Object Type` of `Page` (i.e., "page row") are likewise
     used to expand or revise a previously created IIIF manifest (corresponding
-    to the work that the page is a part of).
+    to the work that the page is a part of), unless the `--metadata-update`
+    flag is used (in which case, page rows are ignored).
 
     After Fester creates or updates any IIIF collections or manifests, it
     updates and returns the CSV files to the user.
@@ -177,6 +194,8 @@ def cli(src, iiif_api_version, server, endpoint, out, iiifhost, loglevel, versio
             payload = [("iiif-version", "v{}".format(iiif_api_version))]
             if iiifhost is not None:
                 payload.append(("iiif-host", iiifhost))
+            if metadata_update:
+                payload.append(("metadata-update", True))
             r = requests.post(
                 post_csv_url, headers=request_headers, files=files, data=payload
             )


### PR DESCRIPTION
Also updates the README to lock down the version number for the suggested `black` installation.