### PR TITLE
[IIIF-1060] Point to new Festerize instance dedicated for ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ Usage: festerize [OPTIONS] SRC...
 Options:
   --server TEXT                  URL of the Fester IIIF manifest service
                                  [default: https://iiif.library.ucla.edu]
-  --endpoint TEXT                API endpoint for CSV uploading  [default:
-                                 /collections]
   --out TEXT                     local directory to put the updated CSV
                                  [default: output]
   --iiifhost TEXT                IIIF image server URL (optional)

--- a/festerize.py
+++ b/festerize.py
@@ -24,9 +24,9 @@ import requests
 )
 @click.option(
     "--server",
-    default="https://iiif.library.ucla.edu",
+    default="https://ingest.iiif.library.ucla.edu",
     show_default=True,
-    help="URL of the Fester IIIF manifest service",
+    help="URL of the Fester service dedicated for ingest",
 )
 @click.option(
     "--endpoint",

--- a/festerize.py
+++ b/festerize.py
@@ -29,12 +29,6 @@ import requests
     help="URL of the Fester service dedicated for ingest",
 )
 @click.option(
-    "--endpoint",
-    default="/collections",
-    show_default=True,
-    help="API endpoint for CSV uploading",
-)
-@click.option(
     "--out",
     default="output",
     show_default=True,
@@ -59,15 +53,7 @@ import requests
     "--version", "-V", is_flag=True, help="Print the version number and exit."
 )
 def cli(
-    src,
-    iiif_api_version,
-    server,
-    endpoint,
-    out,
-    iiifhost,
-    metadata_update,
-    loglevel,
-    version,
+    src, iiif_api_version, server, out, iiifhost, metadata_update, loglevel, version,
 ):
     """Uploads CSV files to the Fester IIIF manifest service for processing.
 
@@ -154,7 +140,7 @@ def cli(
 
     # HTTP request URLs.
     get_status_url = server + "/fester/status"
-    post_csv_url = server + endpoint
+    post_csv_url = server + "/collections"
 
     # HTTP request headers.
     request_headers = {"User-Agent": "{}/{}".format("Festerize", festerize_version)}


### PR DESCRIPTION
Also disables the interface for configuring the upload handler path, since I've verified with our users that they never use it.