### PR TITLE
[IIIF-1090] Use click API to handle --version

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,7 @@
+
+### Bandit config file generated from:
+# 'bandit-config-generator -o .bandit'
+
+# https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html
+assert_used:
+  skips: ['*_test.py', 'test_*.py']

--- a/.bandit
+++ b/.bandit
@@ -1,7 +1,0 @@
-
-### Bandit config file generated from:
-# 'bandit-config-generator -o .bandit'
-
-# https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html
-assert_used:
-  skips: ['*_test.py', 'test_*.py']

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ After it's installed, you can see the available options by running:
 When you do this, you should see the following:
 
 ```
-Usage: festerize [OPTIONS] SRC...
+Usage: festerize [OPTIONS] [SRC]...
 
   Uploads CSV files to the Fester IIIF manifest service for processing.
 
@@ -56,7 +56,8 @@ Usage: festerize [OPTIONS] SRC...
 
   Any rows with an `Object Type` of `Page` (i.e., "page row") are likewise
   used to expand or revise a previously created IIIF manifest (corresponding
-  to the work that the page is a part of).
+  to the work that the page is a part of), unless the `--metadata-update`
+  flag is used (in which case, page rows are ignored).
 
   After Fester creates or updates any IIIF collections or manifests, it
   updates and returns the CSV files to the user.
@@ -88,12 +89,22 @@ Usage: festerize [OPTIONS] SRC...
       SRC is either a path to a CSV file or a Unix-style glob like '*.csv'.
 
 Options:
-  --server TEXT                  URL of the Fester IIIF manifest service
-                                 [default: https://iiif.library.ucla.edu]
+  -v, --iiif-api-version [2|3]   IIIF API version that Fester should use
+                                 [required]
+
+  --server TEXT                  URL of the Fester service dedicated for
+                                 ingest  [default:
+                                 https://ingest.iiif.library.ucla.edu]
+
   --out TEXT                     local directory to put the updated CSV
                                  [default: output]
+
   --iiifhost TEXT                IIIF image server URL (optional)
+  -m, --metadata-update          Only update manifest (work) metadata; don't
+                                 update canvases (pages).
+
   --loglevel [INFO|DEBUG|ERROR]  [default: INFO]
+  --version                      Show the version and exit.
   --help                         Show this message and exit.
 ```
 

--- a/festerize.py
+++ b/festerize.py
@@ -49,11 +49,9 @@ import requests
     default="INFO",
     show_default=True,
 )
-@click.option(
-    "--version", "-V", is_flag=True, help="Print the version number and exit."
-)
+@click.version_option(prog_name="Festerize", message="%(prog)s v%(version)s")
 def festerize(
-    src, iiif_api_version, server, out, iiifhost, metadata_update, loglevel, version,
+    src, iiif_api_version, server, out, iiifhost, metadata_update, loglevel,
 ):
     """Uploads CSV files to the Fester IIIF manifest service for processing.
 
@@ -105,10 +103,7 @@ def festerize(
     """
     festerize_version = pkg_resources.require("Festerize")[0].version
 
-    if version:
-        click.echo("Festerize v{}".format(festerize_version))
-        sys.exit(0)
-    elif len(src) is 0:
+    if len(src) is 0:
         click.echo("Please provide one or more CSV files", err=True)
         sys.exit(1)
 

--- a/festerize.py
+++ b/festerize.py
@@ -52,7 +52,7 @@ import requests
 @click.option(
     "--version", "-V", is_flag=True, help="Print the version number and exit."
 )
-def cli(
+def festerize(
     src, iiif_api_version, server, out, iiifhost, metadata_update, loglevel, version,
 ):
     """Uploads CSV files to the Fester IIIF manifest service for processing.

--- a/festerize.py
+++ b/festerize.py
@@ -101,7 +101,7 @@ def festerize(
     """
     festerize_version = pkg_resources.require("Festerize")[0].version
 
-    if len(src) is 0:
+    if len(src) == 0:
         click.echo("Please provide one or more CSV files", err=True)
         sys.exit(1)
 

--- a/festerize.py
+++ b/festerize.py
@@ -55,8 +55,6 @@ def festerize(
 ):
     """Uploads CSV files to the Fester IIIF manifest service for processing.
 
-    Uploads CSV files to the Fester IIIF manifest service for processing.
-
     Any rows with an `Object Type` of `Collection` (i.e., "collection row")
     found in the CSV are used to create a IIIF collection.
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     install_requires=["beautifulsoup4", "click", "requests"],
     entry_points="""
         [console_scripts]
-        festerize=festerize:cli
+        festerize=festerize:festerize
     """,
 )

--- a/test_festerize.py
+++ b/test_festerize.py
@@ -5,18 +5,16 @@ from click.testing import CliRunner
 from festerize import festerize
 
 
-class TestFesterize:
-    """Tests for Festerize."""
+def test_cli_help():
+    "Tests the --help option."
+    result = CliRunner().invoke(festerize, ["--help"])
 
-    def test_cli_help(self):
-        "Tests the --help option."
-        result = CliRunner().invoke(festerize, ["--help"])
+    assert result.exit_code == 0
 
-        assert result.exit_code == 0
 
-    def test_cli_version(self):
-        """Tests the --version option."""
-        result = CliRunner().invoke(festerize, ["--version"])
+def test_cli_version():
+    """Tests the --version option."""
+    result = CliRunner().invoke(festerize, ["--version"])
 
-        assert result.exit_code == 0
-        assert re.match("Festerize v", result.output) is not None
+    assert result.exit_code == 0
+    assert re.match("Festerize v", result.output) is not None

--- a/test_festerize.py
+++ b/test_festerize.py
@@ -6,7 +6,7 @@ from festerize import festerize
 
 
 def test_cli_help():
-    "Tests the --help option."
+    """Tests the --help option."""
     result = CliRunner().invoke(festerize, ["--help"])
 
     assert result.exit_code == 0

--- a/test_festerize.py
+++ b/test_festerize.py
@@ -1,6 +1,22 @@
+import re
+
+from click.testing import CliRunner
+
+from festerize import festerize
+
+
 class TestFesterize:
     """Tests for Festerize."""
 
-    def test_true(self):
-        """Tests that pytest is setup properly."""
-        assert True
+    def test_cli_help(self):
+        "Tests the --help option."
+        result = CliRunner().invoke(festerize, ["--help"])
+
+        assert result.exit_code == 0
+
+    def test_cli_version(self):
+        """Tests the --version option."""
+        result = CliRunner().invoke(festerize, ["--version"])
+
+        assert result.exit_code == 0
+        assert re.match("Festerize v", result.output) is not None


### PR DESCRIPTION
Note that cc46d30 breaks the test suite, which 6ee1486 fixes. (With real, actual tests!)

Also updates the documentation which was outdated.