### PR TITLE
[SERV-264] Fix erroneous use of BeautifulSoup to retrieve error message

### DIFF
--- a/festerize.py
+++ b/festerize.py
@@ -238,7 +238,7 @@ def festerize(
                 error_page_soup = BeautifulSoup(r.text, features="html.parser")
                 try:
                     # Fester error page via Vert.x
-                    error_cause = error_page_soup.find(id="error-message").string
+                    error_cause = error_page_soup.find(id="error-message").get_text()
                 except AttributeError:
                     # nginx error page with response status code and message in title
                     error_cause = "{} - {}".format(


### PR DESCRIPTION
Tested manually with the problem CSV against a local dev instance of Fester.